### PR TITLE
[FIX] [13.0] avoid to replace sudo when followed by a call to a method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 # command to run tests
 script:
   - git --version
-  - flake8 . --exclude=__init__.py
+  - flake8 . --exclude=__init__.py,tests/data_*
   - coverage run --source odoo_migrate setup.py test
 
 after_success:

--- a/odoo_migrate/migration_scripts/migrate_120_130.py
+++ b/odoo_migrate/migration_scripts/migrate_120_130.py
@@ -22,7 +22,7 @@ _TEXT_REPLACES = {
     ".py": {
         r".*@api.multi.*\n": "",
         r".*@api.one.*\n": "",
-        r"\.sudo\((?P<user>.+)\)": r".with_user(\g<user>)",
+        r"\.sudo\((?P<user>[^/)]+?)\)": r".with_user(\g<user>)",
         r"\.suspend_security": ".sudo",
         r"\"base_suspend_security\",\n": "",
     },

--- a/tests/data_result/module_080_130/models/sale_order.py
+++ b/tests/data_result/module_080_130/models/sale_order.py
@@ -15,8 +15,15 @@ class SaleOrder(models.Model):
 
     @api.cr
     def my_function(self):
-        # something
-        self.sudo()
-        self.with_user(self.env.user)
+        # 13.0 preserve sudo
+        sudo_test = self.sudo()
+        self.sudo().test()
+
+        # 13.0 should replace with with_user
+        sudo_test = self.with_user(self.env.user)
+        self.with_user(self.env.user).test()
+
+        # 13.0 should replace with sudo()
+        suspended = self.sudo()
         self.sudo().write({"name": "name"})
         return

--- a/tests/data_template/module_080/models/sale_order.py
+++ b/tests/data_template/module_080/models/sale_order.py
@@ -17,8 +17,15 @@ class SaleOrder(models.Model):
 
     @api.cr
     def my_function(self):
-        # something
-        self.sudo()
-        self.sudo(self.env.user)
+        # 13.0 preserve sudo
+        sudo_test = self.sudo()
+        self.sudo().test()
+
+        # 13.0 should replace with with_user
+        sudo_test = self.sudo(self.env.user)
+        self.sudo(self.env.user).test()
+
+        # 13.0 should replace with sudo()
+        suspended = self.suspend_security()
         self.suspend_security().write({"name": "name"})
         return


### PR DESCRIPTION
@legalsylvain Sorry, a little bug.... fixed with this commit :smile: 